### PR TITLE
ユーザー編集画面からemail項目を削除

### DIFF
--- a/src/resources/views/layouts/app.blade.php
+++ b/src/resources/views/layouts/app.blade.php
@@ -71,6 +71,8 @@
                                 </a>
                                 @if (Auth::user()->avatar)
                                     <img src="{{ Auth::user()->avatar }}" alt="ユーザimg" class="rounded-circle my-auto" style="height: 30px; width: 30px;">
+                                @else
+                                    <img src="{{ asset('images/no-user-img.png') }}" alt="ユーザimg" class="rounded-circle my-auto" style="height: 30px; width: 30px;">
                                 @endif
                                 <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
                                     <a class="dropdown-item" href="{{ route('logout') }}"

--- a/src/resources/views/users/edit.blade.php
+++ b/src/resources/views/users/edit.blade.php
@@ -16,19 +16,13 @@
                             </div>
                         </div>
                         <div class="form-group row">
-                            {{ Form::label('email', 'メールアドレス', ['class' => 'col-md-4 col-form-label text-md-right']) }}
-                            <div class="col-md-6">
-                                {{ Form::text('email', $user->email, ['class' => 'form-control']) }}
-                            </div>
-                        </div>
-                        <div class="form-group row">
                             {{ Form::label('avatar', 'プロフィール写真', ['class' => 'col-md-4 col-form-label text-md-right']) }}
                             <div class="col-md-6">
                                 <label for="avatar">
                                     @if ($user->avatar)
                                         <img src="{{ $user->avatar }}" alt="" style="width: 150px; height: 150px;" class="rounded-circle cursor-pointer" id="user_img">
                                     @else
-                                        <img src="{{ asset('images/btn_google_signin_light_normal_web.png') }}" alt="" style="width: 150px; height: 150px;" class="cursor-pointer" id="user_img">
+                                        <img src="{{ asset('images/no-user-img.png') }}" alt="" style="width: 150px; height: 150px;" class="cursor-pointer" id="user_img">
                                     @endif
                                 </label>
                                 {{ Form::file('avatar', ['class' => 'd-none', 'onchange' => 'changeImage(this)']) }}


### PR DESCRIPTION
・一度登録したemailを変更出来ないようにするため

・プロフィール画像が未設定の場合に表示する画像の修正
　◎プロフィール画面：
　　googleのボタン画像→ノーユーザー画像
　◎右上のユーザアイコン：
　　何も表示しない→ノーユーザー画像