### PR TITLE
ユーザ情報表示画面の修正（画像が表示されない）

### DIFF
--- a/src/resources/views/users/index.blade.php
+++ b/src/resources/views/users/index.blade.php
@@ -8,7 +8,11 @@
                 <h3 class="h3">ユーザ情報</h3>
                 <div class="card">
                     <div class="card-body text-center">
-                        <img class="rounded-circle d-inline-block" style="width: 100px; height: 100px;" src="{{ $user->avatar }}" alt="ユーザimg">
+                        @if ($user->avatar)
+                            <img class="rounded-circle d-inline-block" style="width: 100px; height: 100px;" src="{{ $user->avatar }}" alt="ユーザimg">
+                        @else
+                            <img class="rounded-circle d-inline-block" style="width: 100px; height: 100px;" src="{{ asset('images/no-user-img.png') }}" alt="ユーザimg">
+                        @endif
                         <h5 class="h5 mt-2">{{ $user->name }}</h5>
                     </div>
                 </div>


### PR DESCRIPTION
・ユーザのプロフィール画像が設定されていない場合に未設定用の画像が表示されない
　→未設定の場合に「no-user-image」を表示するように修正